### PR TITLE
[PR]エラーハンドラ関連のレビュー対応

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,20 @@
  *= require_tree .
  *= require_self
  */
+
+.error-section {
+  display: flex;
+  align-items: center;
+  height: calc(100vh - 136px - 60px);
+}
+
+.error-content {
+  width: 100%;
+  max-width: 350px;
+  padding: 15px;
+  margin: auto;
+}
+
+.error-icon {
+  text-align: center;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,10 @@ class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
 
   include ErrorHandlers if Rails.env.production?
-  
+
   private
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up,keys:[:email])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:email])
   end
 end

--- a/app/controllers/concerns/error_handlers.rb
+++ b/app/controllers/concerns/error_handlers.rb
@@ -1,18 +1,18 @@
 module ErrorHandlers
-    extend ActiveSupport::Concern
+  extend ActiveSupport::Concern
 
-    included do
-        rescue_from StandardError, with: :rescue500
-        rescue_from ActiveRecord::RecordNotFound, with: :rescue404
-    end
+  included do
+    rescue_from StandardError, with: :rescue500
+    rescue_from ActiveRecord::RecordNotFound, with: :rescue404
+  end
 
-    private
+  private
 
-    def rescue404(e)
-        render 'errors/not_found', status: 404
-    end
+  def rescue404
+    render 'errors/not_found', status: :not_found
+  end
 
-    def rescue500(e)
-        render 'errors/internal_server_error', status: 500
-    end
+  def rescue500
+    render 'errors/internal_server_error', status: :internal_server_error
+  end
 end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,6 +1,6 @@
-<div class='error' style='display: flex; align-items: center; height: calc(100vh - 136px - 60px);'>
-  <div class='error-content', style='width: 100%; max-width: 350px; padding: 15px; margin: auto;'>
-    <div style='text-align: center;'>
+<div class='error-section'>
+  <div class='error-content'>
+    <div class='error-icon'>
       <i class='far fa-dizzy fa-5x mb-3 mx-auto'></i>
     </div>
     <h1 class='h3 mb-3 fw-normal text-center'>500 Internal Sever Error</h1>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -3,7 +3,7 @@
     <div style='text-align: center;'>
       <i class='far fa-dizzy fa-5x mb-3 mx-auto'></i>
     </div>
-    <h3 class='h3 mb-3 fw-normal text-center'>500 Internal Sever Error</h3>
+    <h1 class='h3 mb-3 fw-normal text-center'>500 Internal Sever Error</h1>
     <p class='text-center'>申し訳ございません。システムエラーが発生しました。</p>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,6 +1,6 @@
-<div class='error' style='display: flex; align-items: center; height: calc(100vh - 136px - 60px);'>
-  <div class='error-content', style='width: 100%; max-width: 330px; padding: 15px; margin: auto;'>
-    <div style='text-align: center;'>
+<div class='error-section'>
+  <div class='error-content'>
+    <div class='error-icon'>
       <i class='far fa-frown fa-5x mb-3 mx-auto'></i>
     </div>
     <h1 class='h3 mb-3 fw-normal text-center'>404 Not Found</h1>


### PR DESCRIPTION
# レビュー内容
```ruby
diff --git a/app/controllers/concerns/error_handlers.rb
+# 字下げ
```
```ruby
diff --git a/app/views/errors/internal_server_error.html.erb
+ <h3 class='h3 mb-3 fw-normal text-center'>500 Internal Sever Error</h3> # 404ではh1だった
```

# 変更内容
- rubocopのコードフォーマットを適応
- html.erbに直接記述していたCSSをapplication.scssに移動
- h3タグをh1タグに修正
