### PR TITLE
user_postsのルーティングをpostsに変更

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,9 +5,9 @@ class CommentsController < ApplicationController
     @comment = @post.comments.new(comment_params)
     @comment.user_id = current_user.id
     if @comment.save
-      redirect_to user_post_path(id: @post.id, user_id: @post.user.id), success: 'コメントを追加しました。'
+      redirect_to post_path(@post), success: 'コメントを追加しました。'
     else
-      redirect_to user_post_path(@post), danger: 'コメントの追加に失敗しました。'
+      redirect_to post_path(@post), danger: 'コメントの追加に失敗しました。'
     end
   end
 
@@ -30,9 +30,9 @@ class CommentsController < ApplicationController
       @post = @comment.post
     end
     if @comment.update(comment_params)
-      redirect_to user_post_path(id: @post.id, user_id: @post.user.id), success: 'コメントを更新しました。'
+      redirect_to post_path(@post), success: 'コメントを更新しました。'
     else
-      redirect_to user_post_path(id: @post.id, user_id: @post.user.id), danger: 'コメントの更新に失敗しました。'
+      redirect_to post_path(@post), danger: 'コメントの更新に失敗しました。'
     end
   end
 
@@ -45,7 +45,7 @@ class CommentsController < ApplicationController
       @post = @comment.post
     end
     @comment.destroy!
-    redirect_to user_post_path(id: @post.id, user_id: @post.user.id), success: 'コメントを削除しました。'
+    redirect_to post_path(@post), success: 'コメントを削除しました。'
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
 
   def index
     @user = User.find(params[:user_id])
-    @posts = @user.posts.order(created_at: :desc)
+    @posts = @user.posts.order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/views/mypage/index.html.erb
+++ b/app/views/mypage/index.html.erb
@@ -15,7 +15,7 @@
       <div class='col-md6'>
         <div class='row g-0 border rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative'>
           <div class='col-10 p-4 d-flex flex-column position-static'>
-            <h3 class='mb-0'><%= link_to post.title, user_post_path(id: post, user_id: post.user.id) %></h3>
+            <h3 class='mb-0'><%= link_to post.title, post_path(post) %></h3>
             <div class='mb-1 text-muted'><%= l(post.created_at.to_date) %></div>
           </div>
           <div class='col p-4'>
@@ -36,7 +36,7 @@
                   </li>
                 <% else %>
                   <li>
-                    <%= link_to post.user.name, user_posts_path(user_id: post.user.id) %>
+                    <%= link_to post.user.name, posts_path(user_id: post.user.id) %>
                   </li>
                 <% end %>
               </ul>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,6 @@
 <% @title = "#{@user.name}さんの投稿記事一覧" %>
 <div class='row my-3'>
-  <div class='col-6'>
+  <div class='col-12'>
     <h1><%= @title %></h1>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,7 +8,7 @@
       <% if user_signed_in? && current_user.id == @post.user.id %>
         <%= link_to @post.user.name, :mypage_index %>
       <% else %>
-        <%= link_to @post.user.name, user_posts_path(user_id: @post.user.id) %>
+        <%= link_to @post.user.name, posts_path(user_id: @post.user.id) %>
       <% end %>
     </p>
 
@@ -31,7 +31,7 @@
           <% if post_contributor? %>
             <%= link_to comment.user.name, :mypage_index %>
           <% else %>
-            <%= link_to comment.user.name, user_posts_path(user_id: comment.user.id) %>
+            <%= link_to comment.user.name, posts_path(user_id: comment.user.id) %>
           <% end %>
         </p>
         <% if comment_contributor?(comment) %>

--- a/app/views/shared/_post_lists.html.erb
+++ b/app/views/shared/_post_lists.html.erb
@@ -1,25 +1,21 @@
-<div class='row'>
-  <% if @posts.present? %>
-    <% @posts.each do |post| %>
-      <div class='col-md-6'>
-        <div class='row g-0 border rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative'>
-          <div class='col p-4 d-flex flex-column position-static'>
-            <h3 class='mb-0'><%= link_to post.title, user_post_path(id: post, user_id: post.user.id) %></h3>
-            <div class='mb-1 text-muted'><%= l(post.created_at.to_date) %></div>
-            <p class='post-user'>
-              投稿者：
-              <% if user_signed_in? && current_user.id == post.user.id %>
-                <%= link_to post.user.name, :mypage_index %>
-              <% else %>
-                <%= link_to post.user.name, user_posts_path(user_id: post.user.id) %>
-              <% end %>
-            </p>
-          </div>
-        </div>
+<% if @posts.present? %>
+  <% @posts.each do |post| %>
+    <div class='row g-0 border rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative'>
+      <div class='col p-4 d-flex flex-column position-static'>
+        <h3 class='mb-0'><%= link_to post.title, post_path(post) %></h3>
+        <div class='mb-1 text-muted'><%= l(post.created_at.to_date) %></div>
+        <p class='post-user'>
+          投稿者：
+          <% if user_signed_in? && current_user.id == post.user.id %>
+            <%= link_to post.user.name, :mypage_index %>
+          <% else %>
+            <%= link_to post.user.name, posts_path(user_id: post.user.id) %>
+          <% end %>
+        </p>
       </div>
-    <% end %>
-  <% else %>
-    <p>記事がありません</p>
+    </div>
   <% end %>
-</div>
-<%= paginate @posts %>
+  <%= paginate @posts %>
+<% else %>
+  <p>記事がありません</p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,11 +7,7 @@ Rails.application.routes.draw do
     registrations: 'users/registrations'
   }
 
-  resources :users, only: [] do
-    resources :posts, only: [:index, :show]
-  end
-
-  resources :posts, except: [:index, :show] do
+  resources :posts do
     resources :comments, only: [:create, :edit, :update, :destroy]
   end
 

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Comments', type: :request do
 
       it '記事の詳細ページに遷移すること' do
         post post_comments_path(post_id: new_post.id, comment: comment_params)
-        expect(response).to redirect_to user_post_path(id: new_comment.post.id, user_id: new_comment.post.user.id)
+        expect(response).to redirect_to post_path(new_comment.post)
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe 'Comments', type: :request do
 
       it '記事の詳細ページに遷移すること' do
         post post_comments_path(post_id: new_post.id, comment: comment_params)
-        expect(response).to redirect_to user_post_path(id: new_comment.post.id, user_id: new_comment.post.user.id)
+        expect(response).to redirect_to post_path(new_comment.post)
       end
     end
   end
@@ -94,7 +94,7 @@ RSpec.describe 'Comments', type: :request do
       it '記事の詳細ページに遷移すること' do
         comment_params[:content] = 'sample'
         put post_comment_path(id: new_comment.id, post_id: new_comment.post_id, comment: comment_params)
-        expect(response).to redirect_to user_post_path(id: new_comment.post.id, user_id: new_comment.user.id)
+        expect(response).to redirect_to post_path(new_comment.post)
       end
 
       it '自分の記事の異なるユーザーのコメントを更新できること' do

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -15,31 +15,31 @@ RSpec.describe 'Posts', type: :request do
   describe 'GET #index' do
     context 'ログインユーザーの場合' do
       it '自分の記事の一覧ページを見ることができる' do
-        get user_posts_path(user_id: user.id)
+        get posts_path(user_id: user.id)
         expect(response).to have_http_status(:ok)
       end
 
       it '別ユーザーの記事一覧を見ることができる' do
-        get user_posts_path(user_id: other_user.id)
+        get posts_path(user_id: other_user.id)
         expect(response).to have_http_status(:ok)
       end
 
       it '存在しないユーザーの記事一覧ページを閲覧しようとした時' do
         expect {
-          get user_posts_path(user_id: 99)
+          get posts_path(user_id: 99)
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     context 'ユーザーがログインしていない場合' do
       it '別ユーザーの記事一覧を見ることができる' do
-        get user_posts_path(user_id: other_user.id)
+        get posts_path(user_id: other_user.id)
         expect(response).to have_http_status(:ok)
       end
 
       it '存在しないユーザーの記事一覧ページを閲覧しようとした時' do
         expect {
-          get user_posts_path(user_id: 99)
+          get posts_path(user_id: 99)
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -86,14 +86,14 @@ RSpec.describe 'Posts', type: :request do
   describe 'GET #show' do
     context 'ログインユーザーの場合' do
       it 'リクエストが成功すること' do
-        get user_post_path(user_id: new_post.user.id, id: new_post.id)
+        get post_path(new_post)
         expect(response).to have_http_status(:ok)
       end
     end
 
     describe 'ユーザーがログインしていない場合' do
       it 'リクエストが成功すること', :skip_before_action do
-        get user_post_path(user_id: new_post.user.id, id: new_post.id)
+        get post_path(new_post)
         expect(response).to have_http_status(:ok)
       end
     end
@@ -111,6 +111,7 @@ RSpec.describe 'Posts', type: :request do
       before do
         login_as other_user
       end
+
       it '記事を編集するページを見ることができない', :skip_before_action do
         expect {
           get edit_post_path(new_post.id)
@@ -142,6 +143,7 @@ RSpec.describe 'Posts', type: :request do
       before do
         login_as other_user
       end
+
       it 'リクエストが失敗すること', :skip_before_action do
         expect {
           put post_path(id: new_post.id, post: post_params)
@@ -163,7 +165,7 @@ RSpec.describe 'Posts', type: :request do
         delete post_path(id: new_post.id)
         expect(response).to have_http_status(:found)
       end
-  
+
       it '記事が削除されること' do
         expect do
           delete post_path(id: new_post.id)
@@ -175,6 +177,7 @@ RSpec.describe 'Posts', type: :request do
       before do
         login_as other_user
       end
+
       it 'リクエストが失敗すること', :skip_before_action do
         expect {
           delete post_path(id: new_post.id)


### PR DESCRIPTION
# レビュー内容

```ruby
diff --git a/config/routes.rb
+ resources :users, only: [] do # namespace じゃないといけない
+ resources :posts, only: [:index, :show] # この形式だと別ルーティング↓のposts_controllerと同じにならんか？
```

# 変更内容
- resources :users, only: [] doの部分を削除
- usert_post_path, user_posts_pathをそれぞれ、post_path, posts_pathに変更
  - テストも合わせて修正
- 抜けていたページネーションの処理を追加