### PR TITLE
[WIP]会員登録フローをメールアドレス認証から始めるよう変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - rubocop-rails
 - rubocop-rspec
 - htmlbeautifier
+- letter_opener
 
 ### yarn
 - bootstrap5

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -12,11 +12,22 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   # end
 
   # GET /resource/confirmation?confirmation_token=abcdef
-  # def show
-  #   super
-  # end
+  def show
+    self.resource = resource_class.find_by(confirmation_token: params[:confirmation_token])
+    super if !resource || resource.confirmed?
+  end
 
-  # protected
+  def confirm
+    self.resource = resource_class.find_by_confirmation_token(params[:confirmation_token])
+    if resource.update(confirm_params)
+      self.resource = resource_class.confirm_by_token(params[:confirmation_token])
+      redirect_to user_session_path, success: '会員登録が完了しました。'
+    else
+      render :show
+    end
+  end
+
+  protected
 
   # The path used after resending confirmation instructions.
   # def after_resending_confirmation_instructions_path_for(resource_name)
@@ -27,4 +38,8 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   # def after_confirmation_path_for(resource_name, resource)
   #   super(resource_name, resource)
   # end
+
+  def confirm_params
+    params.require(:user).permit(:password, :password_confirmation, :name)
+  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,9 +10,32 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    build_resource(sign_up_params)
+
+    begin
+      resource.save!
+      yield resource if block_given?
+      if resource.persisted?
+        if resource.active_for_authentication?
+          set_flash_message! :notice, :signed_up
+          sign_up(resource_name, resource)
+          respond_with resource, location: after_sign_up_path_for(resource)
+        else
+          set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
+          expire_data_after_sign_in!
+          respond_with resource, location: after_inactive_sign_up_path_for(resource)
+        end
+      else
+        clean_up_passwords resource
+        set_minimum_password_length
+        respond_with resource
+      end
+    rescue ActiveRecord::RecordInvalid
+      set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
+      redirect_to user_session_path
+    end
+  end
 
   # GET /resource/edit
   # def edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :confirmable
 
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,6 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
 
-  validates :name, presence: true, uniqueness: true
-
   def password_required?
     super if confirmed?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,12 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
+
+  def password_required?
+    super if confirmed?
+  end
+
+  def confirmed?
+    !!confirmed_at
+  end
 end

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend confirmation instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: user_confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/users/confirmations/show.html.erb
+++ b/app/views/users/confirmations/show.html.erb
@@ -1,0 +1,18 @@
+<h2>本登録をするためにパスワードを設定してください</h2>
+
+<%= form_for(resource, as: resource_name, url: user_confirmation_path(resource_name), html: { method: :patch }) do |f| %>
+  <%= render "users/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= hidden_field_tag  :confirmation_token, params[:confirmation_token] %>
+    <%= f.text_field :name, autofocus: true, autocomplete: 'name', placeholder: 'ニックネーム', class: 'form-control' %>
+    <%= f.password_field :password, autocomplete: 'new-password', placeholder: "パスワード（#{@minimum_password_length}文字以上）", class: 'form-control' %>
+    <%= f.password_field :password_confirmation, autocomplete: 'new-password', placeholder: 'パスワード（確認用）', class: 'form-control' %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to 'Confirm my account', user_confirmation_path(@resource, confirmation_token: @token) %></p>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -7,10 +7,7 @@
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <%= render 'users/shared/error_messages', resource: resource %>
-      <%= f.text_field :name, autofocus: true, autocomplete: 'name', placeholder: 'ニックネーム', class: 'form-control' %>
       <%= f.email_field :email, autofocus: true, autocomplete: 'email', placeholder: 'メールアドレス', class: 'form-control' %>
-      <%= f.password_field :password, autocomplete: 'new-password', placeholder: "パスワード（#{@minimum_password_length}文字以上）", class: 'form-control' %>
-      <%= f.password_field :password_confirmation, autocomplete: 'new-password', placeholder: 'パスワード（確認用）', class: 'form-control' %>
       <div class='actions'>
         <%= f.submit '会員登録', class: 'w-100 btn btn-lg btn-primary' %>
       </div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "確認メールの再送信はこちら", new_user_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,14 @@ Rails.application.routes.draw do
 
   root 'top#index'
   devise_for :users, controllers: {
-    sessions:      'users/sessions',
+    sessions: 'users/sessions',
     registrations: 'users/registrations',
     confirmations: 'users/confirmations'
   }
+
+  devise_scope :user do
+    patch 'users/confirmation', to: 'users/confirmations#confirm'
+  end
 
   resources :posts do
     resources :comments, only: [:create, :edit, :update, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@ Rails.application.routes.draw do
 
   root 'top#index'
   devise_for :users, controllers: {
-    sessions: 'users/sessions',
-    registrations: 'users/registrations'
+    sessions:      'users/sessions',
+    registrations: 'users/registrations',
+    confirmations: 'users/confirmations'
   }
 
   resources :posts do

--- a/db/migrate/20211009123303_add_confirmable_to_devise_users.rb
+++ b/db/migrate/20211009123303_add_confirmable_to_devise_users.rb
@@ -1,0 +1,11 @@
+class AddConfirmableToDeviseUsers < ActiveRecord::Migration[6.1]
+  def change
+    ## Confirmable
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string
+
+    add_index :users, :confirmation_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_07_094320) do
+ActiveRecord::Schema.define(version: 2021_10_09_123303) do
 
   create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "content", null: false
@@ -40,6 +40,11 @@ ActiveRecord::Schema.define(version: 2021_10_07_094320) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
# レビュー内容
### メールアドレスの登録有無を表示させない
- 会員登録時に既に登録されてるメールアドレスの場合下記のメッセージはセキュリティ的に出さない方が良いかも
- ユーザ情報の変更でもEメールの存在確認ができる実装になっていました。
- 「エラーが発生したため ユーザー は保存されませんでした。Eメールはすでに存在します」

# 変更内容
## 会員登録フローの変更
- メールアドレス入力→メール送信→メールから認証コード付きURLをクリック→会員登録
  - メールアドレスの重複が発生している場合は内部で例外を出してメールを送信したとメッセージを表示しています。

## 未実装
### 各種バリデーション
- deviseのデフォルトの処理から外れたので別途実装が必要？ 
  - ユーザー名
  - メールアドレス
  - パスワード

### 各種登録画面のスタイルシートの修正
- まだデフォルトのまま

## 備考
### deivseのparanoidモードを使って解決しようと試みた
- メールアドレスの重複などを検出することを防ぐモードが存在しました。
- しかしregisterableモジュールはこの機能では保護されないことがわかったので、認証フローを変更するアプローチを取りました。
https://github.com/heartcombo/devise/wiki/How-To:-Using-paranoid-mode,-avoid-user-enumeration-on-registerable



